### PR TITLE
fix(ci): remove full pytest run from secrets-validation workflow

### DIFF
--- a/.github/workflows/secrets-validation.yml
+++ b/.github/workflows/secrets-validation.yml
@@ -22,43 +22,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-      - name: Add uv to PATH
-        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Validate secrets configuration
+      - name: Verify secrets are accessible
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           N8N_API_KEY: ${{ secrets.N8N_API_KEY }}
-          CACHE_METRICS_ENABLED: false
-          CACHE_METRICS_PORT: 9090
-          DEBUG: false
-          ENVIRONMENT: development
         run: |
           python scripts/validate_secrets.py
-
-      - name: Run tests with secrets
-        env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          N8N_API_KEY: ${{ secrets.N8N_API_KEY }}
-          CACHE_METRICS_ENABLED: false
-          CACHE_METRICS_PORT: 9090
-          DEBUG: false
-          ENVIRONMENT: development
-          PYTEST_CURRENT_TEST: true
-        run: |
-          uv run pytest -v


### PR DESCRIPTION
## Problem

The `Secrets Validation` workflow was running the entire test suite (`uv run pytest -v`) with real API keys injected. This caused Gemini integration tests to make live API calls and hit the free-tier daily quota (429 RESOURCE_EXHAUSTED), producing spurious CI failures with no connection to whether secrets were valid.

## Root Cause

The workflow had a step called "Run tests with secrets" that ran `uv run pytest -v` — the full suite, all 5000 tests — as a side effect of checking secret presence. This was likely added under the assumption that "tests need real secrets", but the unit tests are already fully mocked and the integration tests hit live APIs.

## Fix

- **Remove** the `Run tests with secrets` step entirely — the CI workflow already runs the full suite
- **Remove** the uv install chain (`curl | sh`, `uv sync --all-extras`) — `validate_secrets.py` uses only stdlib `os`/`sys`
- **Strip** irrelevant env vars (`CACHE_METRICS_*`, `DEBUG`, `ENVIRONMENT`) from the remaining step
- The workflow now runs in ~5s instead of ~3min and cannot fail due to external API rate limits

## After

Workflow: checkout → `python scripts/validate_secrets.py` → done.