### PR TITLE
feat(llm): SmartRouterPrimitive — zero-config best-available provider cascade

### DIFF
--- a/tests/unit/test_smart_router.py
+++ b/tests/unit/test_smart_router.py
@@ -1,0 +1,260 @@
+"""Tests for SmartRouterPrimitive and AgentRouterPrimitive zero-config defaults."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ttadev.agents.router import AgentRouterPrimitive
+from ttadev.agents.task import AgentResult, AgentTask
+from ttadev.primitives.core.base import WorkflowContext
+from ttadev.primitives.llm.model_router import ModelRouterPrimitive, RouterTierConfig
+from ttadev.primitives.llm.smart_router import SmartRouterPrimitive
+
+# ---------------------------------------------------------------------------
+# SmartRouterPrimitive tests
+# ---------------------------------------------------------------------------
+
+
+class TestSmartRouterBuild:
+    """SmartRouterPrimitive.build() returns a ModelRouterPrimitive."""
+
+    def test_build_returns_model_router(self):
+        router = SmartRouterPrimitive().build()
+        assert isinstance(router, ModelRouterPrimitive)
+
+    def test_make_classmethod_returns_model_router(self):
+        router = SmartRouterPrimitive.make()
+        assert isinstance(router, ModelRouterPrimitive)
+
+    def test_default_mode_name(self):
+        router = SmartRouterPrimitive().build()
+        assert "default" in router.modes
+
+    def test_custom_mode_name(self):
+        router = SmartRouterPrimitive(mode="coding").build()
+        assert "coding" in router.modes
+
+    def test_ollama_always_present(self):
+        """Ollama tier is always included regardless of env vars."""
+        with patch.dict("os.environ", {}, clear=True):
+            router = SmartRouterPrimitive().build()
+        tiers = router.modes["default"].tiers
+        providers = [t.provider for t in tiers]
+        assert "ollama" in providers
+
+    def test_ollama_is_last_tier(self):
+        """Ollama is always the final fallback."""
+        with patch.dict("os.environ", {}, clear=True):
+            router = SmartRouterPrimitive().build()
+        last_tier = router.modes["default"].tiers[-1]
+        assert last_tier.provider == "ollama"
+
+    def test_groq_added_when_key_present(self):
+        env = {"GROQ_API_KEY": "sk-test"}
+        with patch.dict("os.environ", env, clear=False):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert "groq" in providers
+
+    def test_groq_not_added_without_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert "groq" not in providers
+
+    def test_google_added_when_key_present(self):
+        env = {"GOOGLE_API_KEY": "AIza-test"}
+        with patch.dict("os.environ", env, clear=False):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert "google" in providers
+
+    def test_google_not_added_without_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert "google" not in providers
+
+    def test_openrouter_added_when_key_present(self):
+        env = {"OPENROUTER_API_KEY": "sk-or-test"}
+        with patch.dict("os.environ", env, clear=False):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert "openrouter" in providers
+
+    def test_openrouter_not_added_without_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert "openrouter" not in providers
+
+    def test_cascade_order_all_keys(self):
+        """Groq → Google → OpenRouter → Ollama when all keys present."""
+        env = {
+            "GROQ_API_KEY": "sk-g",
+            "GOOGLE_API_KEY": "AIza",
+            "OPENROUTER_API_KEY": "sk-or",
+        }
+        with patch.dict("os.environ", env, clear=False):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert providers == ["groq", "google", "openrouter", "ollama"]
+
+    def test_cascade_order_no_keys(self):
+        """Only Ollama when no keys present."""
+        with patch.dict("os.environ", {}, clear=True):
+            router = SmartRouterPrimitive().build()
+        providers = [t.provider for t in router.modes["default"].tiers]
+        assert providers == ["ollama"]
+
+    def test_custom_or_free_model(self):
+        env = {"OPENROUTER_API_KEY": "sk-or"}
+        with patch.dict("os.environ", env, clear=False):
+            router = SmartRouterPrimitive(
+                or_free_model="meta-llama/llama-3.3-70b-instruct:free"
+            ).build()
+        tiers = router.modes["default"].tiers
+        or_tier = next(t for t in tiers if t.provider == "openrouter")
+        assert or_tier.model == "meta-llama/llama-3.3-70b-instruct:free"
+
+    def test_tiers_are_router_tier_configs(self):
+        router = SmartRouterPrimitive().build()
+        for tier in router.modes["default"].tiers:
+            assert isinstance(tier, RouterTierConfig)
+
+
+# ---------------------------------------------------------------------------
+# AgentRouterPrimitive zero-config tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRouterDefaultModel:
+    """AgentRouterPrimitive accepts model=None and builds SmartRouter."""
+
+    def test_init_with_no_args(self):
+        """Should construct without error."""
+        router = AgentRouterPrimitive()
+        assert router is not None
+
+    def test_init_model_none_by_default(self):
+        router = AgentRouterPrimitive()
+        assert router._model is None
+
+    def test_init_orchestrator_none_by_default(self):
+        router = AgentRouterPrimitive()
+        assert router._orchestrator is None
+
+    def test_get_model_returns_adapter_when_model_none(self):
+        from ttadev.agents.adapter import ModelRouterChatAdapter
+
+        router = AgentRouterPrimitive()
+        model = router._get_model()
+        assert isinstance(model, ModelRouterChatAdapter)
+
+    def test_get_orchestrator_reuses_model_when_none(self):
+        """When orchestrator is None, falls back to the same model."""
+        router = AgentRouterPrimitive()
+        # Both calls should return a ChatPrimitive-compatible object
+        model = router._get_model()
+        orch = router._get_orchestrator()
+        # Both come from SmartRouter — just verify they're chat-compatible
+        assert hasattr(model, "chat")
+        assert hasattr(orch, "chat")
+
+    def test_explicit_model_preserved(self):
+        mock_model = MagicMock()
+        mock_model.chat = AsyncMock(return_value="ok")
+        router = AgentRouterPrimitive(model=mock_model)
+        assert router._get_model() is mock_model
+
+    def test_explicit_orchestrator_preserved(self):
+        mock_orch = MagicMock()
+        mock_orch.chat = AsyncMock(return_value="ok")
+        router = AgentRouterPrimitive(orchestrator=mock_orch)
+        assert router._get_orchestrator() is mock_orch
+
+
+# ---------------------------------------------------------------------------
+# _resolve_default_model integration test
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDefaultModel:
+    """_resolve_default_model now uses SmartRouterPrimitive."""
+
+    def test_returns_chat_primitive_compatible_object(self):
+        from ttadev.primitives.core.base import _resolve_default_model
+
+        model = _resolve_default_model()
+        assert hasattr(model, "chat")
+
+    def test_returns_model_router_chat_adapter(self):
+        from ttadev.agents.adapter import ModelRouterChatAdapter
+        from ttadev.primitives.core.base import _resolve_default_model
+
+        model = _resolve_default_model()
+        assert isinstance(model, ModelRouterChatAdapter)
+
+
+# ---------------------------------------------------------------------------
+# AgentRouterPrimitive routing logic (smoke test with mocked model)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRouterRoutingWithMockModel:
+    """Routing logic works correctly when model is injected."""
+
+    @pytest.mark.asyncio
+    async def test_agent_hint_short_circuits(self):
+        """agent_hint bypasses keyword scoring and LLM call."""
+        mock_model = MagicMock()
+        mock_model.chat = AsyncMock(return_value="some-agent")
+
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.execute = AsyncMock(
+            return_value=AgentResult(
+                agent_name="test-agent",
+                response="done",
+                artifacts=[],
+                suggestions=[],
+                spawned_agents=[],
+                quality_gates_passed=True,
+                confidence=1.0,
+            )
+        )
+
+        mock_agent_class = MagicMock(return_value=mock_agent_instance)
+
+        mock_registry = MagicMock()
+        mock_registry.all.return_value = []
+        mock_registry.get.return_value = mock_agent_class
+
+        router = AgentRouterPrimitive(model=mock_model, registry=mock_registry)
+        task = AgentTask(instruction="test", context={}, constraints=[], agent_hint="test-agent")
+        ctx = WorkflowContext(workflow_id="test")
+
+        result = await router.execute(task, ctx)
+
+        mock_registry.get.assert_called_with("test-agent")
+        assert result.response == "done"
+
+    @pytest.mark.asyncio
+    async def test_no_agents_registered_raises(self):
+        """RuntimeError when registry is empty and LLM fallback tries to dispatch."""
+        mock_model = MagicMock()
+        mock_model.chat = AsyncMock(return_value="unknown-agent")
+
+        mock_registry = MagicMock()
+        mock_registry.all.return_value = []
+        mock_registry.get.side_effect = KeyError("unknown-agent")
+
+        router = AgentRouterPrimitive(
+            model=mock_model, orchestrator=mock_model, registry=mock_registry
+        )
+        task = AgentTask(instruction="do something", context={}, constraints=[])
+        ctx = WorkflowContext(workflow_id="test")
+
+        with pytest.raises(RuntimeError, match="No agents registered"):
+            await router.execute(task, ctx)

--- a/ttadev/agents/router.py
+++ b/ttadev/agents/router.py
@@ -48,20 +48,29 @@ class AgentRouterPrimitive(InstrumentedPrimitive[AgentTask, AgentResult]):
     2. Keyword scoring — if top agent's score margin exceeds threshold, dispatch
     3. LLM fallback — ask orchestrator model to choose from agent descriptions
 
+    When ``model`` or ``orchestrator`` are ``None``, a
+    :class:`~ttadev.primitives.llm.smart_router.SmartRouterPrimitive` is built
+    automatically — cascading through Groq, Google, OpenRouter, and Ollama based
+    on available API keys.  No configuration required.
+
     Example::
 
-        router = AgentRouterPrimitive(model=AnthropicPrimitive(), orchestrator=AnthropicPrimitive())
+        # Zero-config: auto-selects best free provider
+        router = AgentRouterPrimitive()
         result = await router.execute(
             AgentTask(instruction="our test suite is flaky", context={}),
             WorkflowContext(),
         )
         # Routes to QAAgent automatically
+
+        # Or inject explicit models:
+        router = AgentRouterPrimitive(model=AnthropicPrimitive(), orchestrator=AnthropicPrimitive())
     """
 
     def __init__(
         self,
-        model: ChatPrimitive,
-        orchestrator: ChatPrimitive,
+        model: ChatPrimitive | None = None,
+        orchestrator: ChatPrimitive | None = None,
         registry: AgentRegistry | None = None,
     ) -> None:
         super().__init__(name="agent_router")
@@ -70,15 +79,31 @@ class AgentRouterPrimitive(InstrumentedPrimitive[AgentTask, AgentResult]):
         # Registry resolved at call time if not provided at init
         self._registry = registry
 
+    def _get_model(self) -> ChatPrimitive:
+        """Return the model, building SmartRouter default if none was injected."""
+        if self._model is not None:
+            return self._model
+        from ttadev.agents.adapter import ModelRouterChatAdapter
+        from ttadev.primitives.llm.smart_router import SmartRouterPrimitive
+
+        return ModelRouterChatAdapter(SmartRouterPrimitive.make())
+
+    def _get_orchestrator(self) -> ChatPrimitive:
+        """Return the orchestrator, reusing the model if none was injected."""
+        if self._orchestrator is not None:
+            return self._orchestrator
+        return self._get_model()
+
     async def _execute_impl(self, task: AgentTask, ctx: WorkflowContext) -> AgentResult:
         registry = self._registry or get_registry()
         agent_classes = registry.all()
+        model = self._get_model()
 
         # 1. agent_hint short-circuit
         if task.agent_hint:
             try:
                 agent_class = registry.get(task.agent_hint)
-                agent = agent_class(model=self._model)
+                agent = agent_class(model=model)
                 result = await agent.execute(task, ctx)
                 return result
             except KeyError:
@@ -90,7 +115,7 @@ class AgentRouterPrimitive(InstrumentedPrimitive[AgentTask, AgentResult]):
             spec = getattr(agent_class, "_class_spec", None)
             if spec is None:
                 # Fallback for agents without _class_spec: instantiate temporarily
-                spec = agent_class(model=self._model).spec
+                spec = agent_class(model=model).spec
             caps = spec.capabilities
             name = spec.name
             scores[name] = _score_agent(task.instruction, caps)
@@ -102,21 +127,23 @@ class AgentRouterPrimitive(InstrumentedPrimitive[AgentTask, AgentResult]):
             margin = best_score - second_score
 
             if best_score > 0 and margin >= _ROUTING_CONFIDENCE_THRESHOLD:
-                agent = registry.get(best_name)(model=self._model)
+                agent = registry.get(best_name)(model=model)
                 return await agent.execute(task, ctx)
+
+        orchestrator = self._get_orchestrator()
 
         # 3. LLM fallback — read specs from class attribute without instantiation
         agent_descriptions = "\n".join(
             f"- {spec.name}: {', '.join(spec.capabilities)}"
             for ac in agent_classes
-            for spec in [getattr(ac, "_class_spec", None) or ac(model=self._model).spec]
+            for spec in [getattr(ac, "_class_spec", None) or ac(model=model).spec]
         )
         prompt = (
             f"Choose the best agent for this task: {task.instruction!r}\n\n"
             f"Available agents:\n{agent_descriptions}\n\n"
             "Reply with only the agent name."
         )
-        chosen_name = await self._orchestrator.chat(
+        chosen_name = await orchestrator.chat(
             [{"role": "user", "content": prompt}],
             system=None,
             ctx=ctx,
@@ -124,11 +151,11 @@ class AgentRouterPrimitive(InstrumentedPrimitive[AgentTask, AgentResult]):
         chosen_name = chosen_name.strip().lower()
 
         try:
-            agent = registry.get(chosen_name)(model=self._model)
+            agent = registry.get(chosen_name)(model=model)
         except KeyError:
             # Fallback: use first registered agent
             if agent_classes:
-                agent = agent_classes[0](model=self._model)
+                agent = agent_classes[0](model=model)
             else:
                 raise RuntimeError("No agents registered in registry.")
 

--- a/ttadev/primitives/core/base.py
+++ b/ttadev/primitives/core/base.py
@@ -363,9 +363,9 @@ class WorkflowContext(BaseModel):
 def _resolve_default_model() -> Any:
     """Attempt to create a default ``ChatPrimitive`` for ``spawn_agent``.
 
-    Tries to build a :class:`~ttadev.agents.adapter.ModelRouterChatAdapter`
-    backed by a :class:`~ttadev.primitives.llm.ModelRouterPrimitive` with a
-    local Ollama tier.  This requires no API keys and works fully offline.
+    Uses :class:`~ttadev.primitives.llm.smart_router.SmartRouterPrimitive`
+    to build a cascade through the best available free providers
+    (Groq → Google Gemini → OpenRouter → Ollama) based on env vars.
 
     Returns:
         A ``ChatPrimitive``-compatible model adapter.
@@ -377,15 +377,9 @@ def _resolve_default_model() -> Any:
     """
     try:
         from ttadev.agents.adapter import ModelRouterChatAdapter
-        from ttadev.primitives.llm.model_router import (
-            ModelRouterPrimitive,
-            RouterModeConfig,
-            RouterTierConfig,
-        )
+        from ttadev.primitives.llm.smart_router import SmartRouterPrimitive
 
-        router = ModelRouterPrimitive(
-            modes={"default": RouterModeConfig(tiers=[RouterTierConfig(provider="ollama")])}
-        )
+        router = SmartRouterPrimitive.make()
         return ModelRouterChatAdapter(router)
     except Exception as exc:
         raise ValueError(

--- a/ttadev/primitives/llm/__init__.py
+++ b/ttadev/primitives/llm/__init__.py
@@ -80,6 +80,7 @@ from ttadev.primitives.llm.providers import (
     get_provider,
     openai_compat_providers,
 )
+from ttadev.primitives.llm.smart_router import SmartRouterPrimitive
 from ttadev.primitives.llm.task_selector import (
     COMPLEXITY_COMPLEX,
     COMPLEXITY_MODERATE,
@@ -149,6 +150,8 @@ __all__ = [
     "ModelRouterRequest",
     "RouterModeConfig",
     "RouterTierConfig",
+    # smart router (zero-config cascade)
+    "SmartRouterPrimitive",
     # task-aware selection
     "TaskProfile",
     "TASK_CODING",

--- a/ttadev/primitives/llm/smart_router.py
+++ b/ttadev/primitives/llm/smart_router.py
@@ -1,0 +1,139 @@
+"""SmartRouterPrimitive — zero-config best-available-model router.
+
+Builds a :class:`~ttadev.primitives.llm.model_router.ModelRouterPrimitive`
+that cascades through available free providers in quality order:
+
+1. **Groq** — fastest inference, generous free tier (GROQ_API_KEY)
+2. **Google Gemini** — reliable free tier (GOOGLE_API_KEY)
+3. **OpenRouter** — aggregator with many free model options (OPENROUTER_API_KEY)
+4. **Ollama** — local fallback, no API key required
+
+Each tier is included only when the corresponding API key env var is set (or
+for Ollama, always included as last resort).  The returned router plugs into
+any component that accepts a :class:`~ttadev.primitives.llm.model_router.ModelRouterPrimitive`.
+
+Usage::
+
+    from ttadev.primitives.llm.smart_router import SmartRouterPrimitive
+
+    router = SmartRouterPrimitive.build()
+    # Wrap in adapter for ChatPrimitive protocol:
+    from ttadev.agents.adapter import ModelRouterChatAdapter
+    model = ModelRouterChatAdapter(SmartRouterPrimitive.build())
+
+    # Or use directly in AgentRouterPrimitive (auto-wired when model=None):
+    from ttadev.agents.router import AgentRouterPrimitive
+    router_prim = AgentRouterPrimitive()  # SmartRouter is the default
+
+Attribution:
+    Model benchmark data sourced from Artificial Analysis (https://artificialanalysis.ai).
+"""
+
+from __future__ import annotations
+
+import os
+
+from ttadev.primitives.llm.model_router import (
+    ModelRouterPrimitive,
+    RouterModeConfig,
+    RouterTierConfig,
+)
+
+__all__ = ["SmartRouterPrimitive"]
+
+# OpenRouter free model — high capability, cost $0.
+_OR_FREE_MODEL = "google/gemma-3-27b-it:free"
+
+# Best free Groq model for general-purpose tasks.
+_GROQ_DEFAULT_MODEL: str | None = None  # let providers.py pick the default
+
+
+class SmartRouterPrimitive:
+    """Factory for a zero-config, best-available-provider router.
+
+    This is not itself a primitive (it wraps one).  Use
+    :meth:`build` to obtain a configured
+    :class:`~ttadev.primitives.llm.model_router.ModelRouterPrimitive`.
+
+    Example::
+
+        router = SmartRouterPrimitive.build()
+        adapter = ModelRouterChatAdapter(router)
+        agent = DeveloperAgent.with_router(router)
+
+    Args:
+        mode: Routing mode label (default: ``"default"``).
+        or_free_model: OpenRouter free-model slug to prefer.  Defaults to
+            ``google/gemma-3-27b-it:free``.
+    """
+
+    def __init__(
+        self,
+        mode: str = "default",
+        or_free_model: str = _OR_FREE_MODEL,
+    ) -> None:
+        self._mode = mode
+        self._or_free_model = or_free_model
+
+    def build(self) -> ModelRouterPrimitive:
+        """Build and return the configured ``ModelRouterPrimitive``.
+
+        Provider tiers are included based on available env vars:
+
+        - **Groq** when ``GROQ_API_KEY`` is set
+        - **Google** when ``GOOGLE_API_KEY`` is set
+        - **OpenRouter** when ``OPENROUTER_API_KEY`` is set
+        - **Ollama** always (local, no key required)
+
+        Returns:
+            A ready-to-use ``ModelRouterPrimitive`` that cascades through
+            available providers in quality/speed order.
+        """
+        tiers = self._build_tiers()
+        modes = {
+            self._mode: RouterModeConfig(
+                description="Auto-cascade through best available free providers",
+                tiers=tiers,
+            )
+        }
+        kwargs: dict = {}
+        if os.environ.get("GROQ_API_KEY"):
+            kwargs["groq_api_key"] = os.environ["GROQ_API_KEY"]
+        if os.environ.get("GOOGLE_API_KEY"):
+            kwargs["google_api_key"] = os.environ["GOOGLE_API_KEY"]
+        if os.environ.get("OPENROUTER_API_KEY"):
+            kwargs["openrouter_api_key"] = os.environ["OPENROUTER_API_KEY"]
+
+        return ModelRouterPrimitive(modes=modes, **kwargs)
+
+    def _build_tiers(self) -> list[RouterTierConfig]:
+        """Return ordered tier list based on available API keys."""
+        tiers: list[RouterTierConfig] = []
+
+        if os.environ.get("GROQ_API_KEY"):
+            tiers.append(RouterTierConfig(provider="groq", model=_GROQ_DEFAULT_MODEL))
+
+        if os.environ.get("GOOGLE_API_KEY"):
+            tiers.append(RouterTierConfig(provider="google"))
+
+        if os.environ.get("OPENROUTER_API_KEY"):
+            tiers.append(RouterTierConfig(provider="openrouter", model=self._or_free_model))
+
+        # Ollama is always the final fallback (no key required).
+        tiers.append(RouterTierConfig(provider="ollama"))
+
+        return tiers
+
+    @classmethod
+    def make(cls, **kwargs: object) -> ModelRouterPrimitive:
+        """Class-level shortcut: ``SmartRouterPrimitive.make()`` → router.
+
+        Equivalent to ``SmartRouterPrimitive().build()``.
+
+        Args:
+            **kwargs: Forwarded to :class:`SmartRouterPrimitive.__init__`.
+
+        Returns:
+            Configured ``ModelRouterPrimitive``.
+        """
+        return cls(**kwargs).build()  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Implements #302 and #314 together.

### SmartRouterPrimitive (#302)

New factory in `ttadev/primitives/llm/smart_router.py` that builds a `ModelRouterPrimitive` using only providers whose env vars are set:

| Priority | Provider | Env var required |
|---|---|---|
| 1st | Groq | `GROQ_API_KEY` |
| 2nd | Google Gemini | `GOOGLE_API_KEY` |
| 3rd | OpenRouter (free tier) | `OPENROUTER_API_KEY` |
| 4th | Ollama | Always included (no key) |

### Wire as default (#314)

- **`AgentRouterPrimitive`**: `model`/`orchestrator` now default to `None`; lazy `_get_model()`/`_get_orchestrator()` build SmartRouter on first use
- **`WorkflowContext.spawn_agent`**: `_resolve_default_model()` upgraded from Ollama-only to full SmartRouter cascade

### Tests
27 unit tests covering cascade logic, provider detection, zero-config init, and routing behaviour.

Closes #302
Closes #314