### PR TITLE
feat(cli): tta status command

### DIFF
--- a/ttadev/cli/status.py
+++ b/ttadev/cli/status.py
@@ -2,9 +2,28 @@
 
 No external dependencies beyond stdlib (json, os, pathlib, socket, time) and
 internal TTA.dev modules.
+
+Public API
+----------
+cmd_status
+    Entry point called by ``tta status``; returns 0 (healthy) or 1 (all down).
+_check_port
+    Thin TCP probe helper; tested independently so mocks patch at this level.
+_count_control_plane
+    Reads active task/run counts from the control-plane store; safe to call
+    when the store has not been initialised yet.
+_provider_slug
+    Derives a short display name from a :class:`~ttadev.cli.setup.SetupProvider`.
 """
 
 from __future__ import annotations
+
+__all__ = [
+    "cmd_status",
+    "_check_port",
+    "_count_control_plane",
+    "_provider_slug",
+]
 
 import json
 import socket


### PR DESCRIPTION
## Summary

Implements `tta status` — a quick system health check command for TTA.dev (closes #328).

## What `tta status` does

```
$ tta status

TTA.dev status
══════════════════════════════════════════════

Providers
  ✓ groq         latency 312 ms
  ✗ google       MISSING key — run `tta setup`
  - ollama       not detected at localhost:11434

Observability
  ✓ dashboard    http://localhost:8000  (running)
  ✗ mcp-server   not running on port 9999

Control plane
  Active tasks   0
  Active runs    0

Config          .env  (1 provider configured)
```

Also supports `--json` for machine-readable output.

## Implementation

| File | Purpose |
|------|---------|
| `ttadev/cli/status.py` | `cmd_status()` + helpers: `_check_port`, `_count_control_plane`, `_provider_slug` |
| `ttadev/cli/__init__.py` | `status` subparser registered with `--json` flag; dispatch wired |
| `tests/unit/test_cli_status.py` | 17 unit tests (all pass) |

### Design choices
- **Zero new dependencies** — stdlib only (`socket`, `json`, `time`)
- **Reuses** `SETUP_PROVIDERS` / `validate_provider` / `_get_key` / `_read_env` from `ttadev.cli.setup`
- **Exit codes**: 0 if ≥1 provider healthy; 1 if all missing/failing
- **Safe control-plane probe**: `_count_control_plane` swallows all exceptions (store may not be initialised)
- **JSON output** never includes raw key values

## Quality Gates

- ✅ `uv run pytest tests/unit/test_cli_status.py -v` → 17/17 passed
- ✅ `uv run ruff format` + `ruff check --fix` → clean
- ✅ `uvx pyright ttadev/cli/status.py` → 0 errors, 0 warnings
- ✅ Pre-commit hooks (semgrep, bandit, detect-secrets) → all passed

Closes #328