### PR TITLE
docs: agent-first guide and QUICKSTART improvements

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,92 +1,215 @@
-# TTA.dev Quickstart - Current Verified Proof Path
+# TTA.dev Quickstart
 
-This guide is intentionally narrow: it documents the shortest flow we have re-verified in a clean
-clone.
+> **AI coding agent?** Jump to the [30-second version](#30-second-version) or read
+> [`docs/agent-first.md`](docs/agent-first.md) for agent-specific orientation.
 
-It proves the current foundation works. It does **not** claim that every legacy demo script or
-future-facing feature in the repository is ready yet.
+---
 
-## Step 1: Clone and setup
+## 30-second version
+
+No API key required. Works in any clean clone.
 
 ```bash
 git clone https://github.com/theinterneti/TTA.dev.git
 cd TTA.dev
 ./setup.sh
+
+# Terminal 1 — start the observability dashboard
+uv run python -m ttadev.observability
+
+# Terminal 2 — run the 3-agent showcase (mock LLM, no key needed)
+uv run pytest tests/integration/test_multi_agent_proof.py -v
 ```
 
-## Step 2: Start the observability server
+Open **http://localhost:8000** to watch live traces stream in.
 
-In terminal 1:
+---
+
+## What just happened
+
+The integration test ran a full `feature_dev` pipeline:
+
+```
+DeveloperAgent → QAAgent → SecurityAgent
+```
+
+Each step was tracked by the L0 control plane, and every span was written to
+`.observability/traces.jsonl` and streamed to the dashboard. No API keys, no
+external services — the mock LLM returns deterministic responses so the suite
+stays CI-safe.
+
+---
+
+## Working with real code — the showcase pipeline
+
+The showcase is a **Smart Code Reviewer** that runs parallel static analysis plus
+an LLM review. It's a realistic demonstration of how to compose TTA.dev primitives:
+
+```bash
+# Mock mode — no API key
+uv run python -m examples.showcase.main examples/resilient_llm_pipeline.py --mock
+
+# Live mode — set GROQ_API_KEY first (free at https://console.groq.com)
+GROQ_API_KEY=gsk_... uv run python -m examples.showcase.main examples/resilient_llm_pipeline.py
+```
+
+The showcase wires together `ParallelPrimitive`, `RetryPrimitive`, and
+`CircuitBreakerPrimitive` with automatic OTel tracing — see
+[`examples/showcase/`](examples/showcase/) for the full source.
+
+---
+
+## Step-by-step setup
+
+### 1 — Clone and install
+
+```bash
+git clone https://github.com/theinterneti/TTA.dev.git
+cd TTA.dev
+./setup.sh          # installs deps via uv, prints the proof path
+```
+
+### 2 — (Optional) Configure an LLM provider
+
+Copy `.env.example` to `.env` and fill in **one** provider:
+
+| Provider | Speed | Free? |
+|----------|-------|-------|
+| **Groq** | Fast | Yes — <https://console.groq.com> |
+| **Ollama** | Local | Yes — <https://ollama.ai> |
+| **OpenRouter** | Many models | Yes (limited) — <https://openrouter.ai> |
+
+```bash
+cp .env.example .env
+# edit .env and add e.g. GROQ_API_KEY=gsk_...
+```
+
+Everything works without a key using mock mode. A key unlocks live LLM calls.
+
+### 3 — Start the observability dashboard
 
 ```bash
 uv run python -m ttadev.observability
+# → http://localhost:8000
 ```
 
-Expected result:
+Verify it's healthy:
 
-- the dashboard starts on `http://localhost:8000`
-- `GET /api/v2/health` returns `{"status": "ok", ...}`
+```bash
+curl http://localhost:8000/api/v2/health
+# {"status": "ok", ...}
+```
 
-## Step 3: Generate trace data
-
-In terminal 2:
+### 4 — Generate trace data
 
 ```bash
 uv run python scripts/test_realtime_traces.py
 ```
 
-Expected result:
-
-- the script exits successfully
+Expected:
+- script exits with no errors
 - `.observability/traces.jsonl` is created
-- the server begins exposing spans at `http://localhost:8000/api/v2/spans`
-
-You can check directly with:
+- `/api/v2/spans` returns spans (wait a few seconds — ingestion is async)
 
 ```bash
-curl http://localhost:8000/api/v2/health
 curl http://localhost:8000/api/v2/spans | head
 ```
 
-## Step 4: Run the multi-agent workflow (no API key needed)
+### 5 — Run the multi-agent proof (no API key)
 
 ```bash
 uv run pytest tests/integration/test_multi_agent_proof.py -v
 ```
 
-This executes a 3-agent `feature_dev` workflow (developer → qa → security) with L0 task tracking,
-using a deterministic mock LLM — no API keys required, CI-safe.
+This runs a documented, repeatable 3-agent workflow with L0 task tracking. It is
+the canonical CI-safe proof path.
 
-To run it live via the CLI (requires Ollama or an `OPENROUTER_API_KEY`):
+---
 
-```bash
-tta workflow run feature_dev --goal "Add a health check endpoint" --track-l0 --no-confirm
-tta control task show <task_id from output>
+## Build your first primitive workflow
+
+```python
+import asyncio
+
+from ttadev.primitives import (
+    CachePrimitive,
+    RetryPrimitive,
+    TimeoutPrimitive,
+    WorkflowContext,
+)
+from ttadev.primitives.core.base import LambdaPrimitive
+
+
+async def fetch_data(url: str, ctx: WorkflowContext) -> dict:
+    """Simulate a small async operation."""
+    await asyncio.sleep(0.1)
+    return {"url": url, "status": "ok"}
+
+
+async def main() -> None:
+    base = LambdaPrimitive(fetch_data)
+
+    # Compose: timeout wraps cache wraps retry wraps base
+    workflow = TimeoutPrimitive(
+        CachePrimitive(
+            RetryPrimitive(base),
+            cache_key_fn=lambda url, ctx: f"{ctx.workflow_id}:{url}",
+            ttl_seconds=60.0,
+        ),
+        timeout_seconds=5.0,
+    )
+
+    ctx = WorkflowContext(workflow_id="my-first-workflow")
+    result = await workflow.execute("https://example.test", ctx)
+    print(result)  # {"url": "https://example.test", "status": "ok"}
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
-## What this proves today
+Save as `my_workflow.py` and run with `uv run python my_workflow.py`.
 
-1. the current `ttadev.primitives` composition API works for a basic sequential workflow
-2. the `python -m ttadev.observability` entrypoint is valid
-3. trace ingestion into the v2 observability API works after a short delay
-4. a 3-agent multi-agent workflow runs end-to-end with L0 task/step tracking
+---
 
-## What this does **not** prove yet
+## What this proves
 
-- that every onboarding path in older docs is up to date
-- that the repo is fully production-ready end to end
+| Claim | How verified |
+|-------|-------------|
+| `ttadev.primitives` composition API works | `test_multi_agent_proof.py` passes |
+| Observability server starts | `GET /api/v2/health` returns `{"status": "ok"}` |
+| Trace ingestion works | `/api/v2/spans` returns data after `test_realtime_traces.py` |
+| 3-agent workflow runs end-to-end with L0 tracking | Integration test output |
 
-## Recommended next reads
+---
 
-- [`GETTING_STARTED.md`](GETTING_STARTED.md) for the current setup story
-- [`USER_JOURNEY.md`](USER_JOURNEY.md) for the long-term vision vs current reality
-- [`ROADMAP.md`](ROADMAP.md) for implemented vs planned work
+## What this does not prove yet
+
+- Every path in older docs is up to date
+- The repo is fully production-ready end to end
+- All LLM integrations work identically across providers
+
+---
+
+## Next reads
+
+| Topic | File |
+|-------|------|
+| Full setup story + LLM configuration | [`GETTING_STARTED.md`](GETTING_STARTED.md) |
+| Agent-first orientation (for coding agents) | [`docs/agent-first.md`](docs/agent-first.md) |
+| All primitives with API reference | [`PRIMITIVES_CATALOG.md`](PRIMITIVES_CATALOG.md) |
+| Observability deep-dive | [`docs/observability-quickstart.md`](docs/observability-quickstart.md) |
+| Vision vs current reality | [`USER_JOURNEY.md`](USER_JOURNEY.md) |
+| Implemented vs planned | [`ROADMAP.md`](ROADMAP.md) |
+| Agent instructions (AGENTS.md) | [`AGENTS.md`](AGENTS.md) |
+
+---
 
 ## Notes
 
-- If `/api/v2/spans` is empty immediately after the script runs, wait a few seconds and query it
-  again. The ingestion loop is asynchronous.
-- `examples/demo_workflow.py` and `ttadev/hello_world.py` are lightweight working demos, but the
-  canonical proof path remains the one in this file.
-- Older commands that reference `src/...` or `ttadev/ui/observability_server.py` are stale and
-  should not be treated as canonical proof paths.
+- If `/api/v2/spans` is empty right after the script runs, wait a few seconds and
+  retry. The ingestion loop is asynchronous.
+- `examples/demo_workflow.py` and `ttadev/hello_world.py` are lightweight demos.
+  The canonical proof path is the integration test above.
+- Commands referencing `src/...` or `ttadev/ui/observability_server.py` are stale.
+  Use `python -m ttadev.observability` instead.

--- a/docs/agent-first.md
+++ b/docs/agent-first.md
@@ -1,0 +1,464 @@
+# Agent-First Guide — TTA.dev
+
+> **This file is written for coding agents** (Claude Code, GitHub Copilot, OpenCode,
+> Cline, etc.). Humans are welcome too, but structure and phrasing prioritise
+> machine-readable clarity over narrative flow.
+
+---
+
+## 1. Orientation — what to read first
+
+Start with this file, then follow the chain below. Do **not** start editing until
+you have at least read steps 1–3.
+
+| Priority | File | What it tells you |
+|----------|------|------------------|
+| **1** | `AGENTS.md` | Universal rules, commands, routing table |
+| **2** | `CLAUDE.md` | Claude Code specifics, SDD mandate, skills table |
+| **3** | `PRIMITIVES_CATALOG.md` | Full primitive API surface |
+| **4** | `docs/agent-guides/primitives-patterns.md` | Composition patterns, operators |
+| **5** | `docs/agent-guides/testing-architecture.md` | Test standards, `MockPrimitive` API |
+| **6** | `docs/agent-guides/python-standards.md` | Types, naming, imports |
+
+If you are working inside an MCP-enabled IDE, call `tta_bootstrap` first —
+it returns a compressed orientation package in a single round-trip:
+
+```python
+# MCP tool call (Claude Desktop / VS Code / Cline)
+result = tta_bootstrap(agent_id="my-agent", task_hint="add retry to LLM calls")
+# result contains: version, top_primitives, quick_start, key_files, rules
+```
+
+---
+
+## 2. Repository layout (machine-readable)
+
+```
+TTA.dev/
+├── ttadev/                     # Main importable package
+│   ├── primitives/             # ← Start here for workflow logic
+│   │   ├── core/               # Base classes, sequential, parallel, routing
+│   │   ├── recovery/           # RetryPrimitive, FallbackPrimitive, TimeoutPrimitive, CircuitBreakerPrimitive
+│   │   ├── performance/        # CachePrimitive
+│   │   ├── testing/            # MockPrimitive
+│   │   ├── llm/                # UniversalLLMPrimitive, LLMProvider
+│   │   └── __init__.py         # All public exports (check here for import paths)
+│   ├── agents/                 # DeveloperAgent, QAAgent, SecurityAgent, registry, router
+│   ├── workflows/              # WorkflowDefinition, WorkflowOrchestrator
+│   ├── control_plane/          # L0 task/step tracking, leases
+│   ├── cli/                    # `tta` CLI subcommands
+│   └── observability/          # OTel tracing setup
+├── tests/
+│   ├── integration/            # test_multi_agent_proof.py — canonical CI proof
+│   └── fakes.py                # MockChatPrimitive and test fakes
+├── examples/
+│   ├── showcase/               # Smart Code Reviewer — realistic multi-primitive demo
+│   └── resilient_llm_pipeline.py  # Retry + CircuitBreaker + OTel example
+├── docs/
+│   ├── agent-first.md          # ← this file
+│   ├── agent-guides/           # Deep reference docs (primitives, testing, python standards)
+│   └── observability-quickstart.md
+├── .github/skills/             # Copilot skills (build-test-verify, git-commit, etc.)
+├── .claude/skills/             # Claude Code skills (session-start, sdd-workflow, etc.)
+├── AGENTS.md                   # Universal agent entry point
+├── CLAUDE.md                   # Claude Code configuration
+├── QUICKSTART.md               # Shortest verified proof path
+└── PRIMITIVES_CATALOG.md       # Full primitive reference
+```
+
+---
+
+## 3. The one rule you must follow first
+
+> **Never write manual retry loops, manual timeout logic, or manual circuit
+> breakers.** Use the primitives. The linter enforces this; the reviewer will
+> reject it.
+
+```python
+# ❌ WRONG — never do this
+for attempt in range(3):
+    try:
+        result = await call_api()
+        break
+    except Exception:
+        await asyncio.sleep(2 ** attempt)
+
+# ✅ CORRECT — use RetryPrimitive
+from ttadev.primitives import RetryPrimitive, WorkflowContext
+from ttadev.primitives.core.base import LambdaPrimitive
+
+api_call = LambdaPrimitive(call_api)
+workflow = RetryPrimitive(api_call, max_retries=3, backoff_factor=2.0)
+result = await workflow.execute(input_data, ctx)
+```
+
+---
+
+## 4. Primitive composition pattern
+
+All primitives share the same interface:
+
+```python
+async def execute(self, input_data: TInput, context: WorkflowContext) -> TOutput:
+    ...
+```
+
+### 4.1 Import paths
+
+```python
+# Preferred — import from the package root
+from ttadev.primitives import (
+    WorkflowPrimitive,
+    WorkflowContext,
+    LambdaPrimitive,
+    SequentialPrimitive,
+    ParallelPrimitive,
+    RouterPrimitive,
+    RetryPrimitive,
+    FallbackPrimitive,
+    TimeoutPrimitive,
+    CompensationPrimitive,
+    CachePrimitive,
+    MockPrimitive,
+)
+
+# For CircuitBreakerPrimitive (not yet on package root):
+from ttadev.primitives.recovery.circuit_breaker_primitive import (
+    CircuitBreakerPrimitive,
+    CircuitBreakerConfig,
+)
+
+# For UniversalLLMPrimitive:
+from ttadev.primitives import UniversalLLMPrimitive, LLMProvider, LLMRequest, LLMResponse
+```
+
+### 4.2 Composition operators
+
+```python
+# >> chains primitives sequentially (output of left → input of right)
+pipeline = step_a >> step_b >> step_c
+
+# | runs primitives in parallel (same input to all, returns list of results)
+fan_out = branch_a | branch_b | branch_c
+
+# Combined
+workflow = preprocess >> (fast_path | slow_path) >> aggregate
+```
+
+### 4.3 Wrapping pattern
+
+Recovery and performance primitives wrap an inner primitive:
+
+```python
+workflow = TimeoutPrimitive(
+    CachePrimitive(
+        RetryPrimitive(base_call, max_retries=3),
+        cache_key_fn=lambda data, ctx: f"cache:{data}",
+        ttl_seconds=300.0,
+    ),
+    timeout_seconds=10.0,
+)
+```
+
+### 4.4 Full working example — resilient LLM call
+
+```python
+import asyncio
+from ttadev.primitives import RetryPrimitive, WorkflowContext
+from ttadev.primitives.core.base import LambdaPrimitive
+from ttadev.primitives.recovery.circuit_breaker_primitive import (
+    CircuitBreakerConfig,
+    CircuitBreakerPrimitive,
+)
+
+
+async def call_llm(prompt: str, ctx: WorkflowContext) -> str:
+    """Replace with a real LLM call in production."""
+    return f"response to: {prompt}"
+
+
+async def main() -> None:
+    ctx = WorkflowContext(workflow_id="demo")
+
+    pipeline = CircuitBreakerPrimitive(
+        primitive=RetryPrimitive(
+            LambdaPrimitive(call_llm),
+            max_retries=3,
+        ),
+        config=CircuitBreakerConfig(failure_threshold=5),
+    )
+
+    result = await pipeline.execute("What is 2+2?", ctx)
+    print(result)
+
+
+asyncio.run(main())
+```
+
+See [`examples/resilient_llm_pipeline.py`](../examples/resilient_llm_pipeline.py) for
+the full runnable version (mock mode + live Groq mode).
+
+---
+
+## 5. State — always use WorkflowContext
+
+```python
+from ttadev.primitives import WorkflowContext
+
+# Create a context per workflow run
+ctx = WorkflowContext(workflow_id="my-workflow-123")
+
+# Read/write shared state
+ctx.set("key", value)
+value = ctx.get("key")
+
+# Metadata
+ctx.workflow_id   # str
+ctx.metadata      # dict[str, Any]
+```
+
+**Never use globals** to share state between primitives. Pass `ctx` through.
+
+---
+
+## 6. Writing tests
+
+### 6.1 Test file layout
+
+```python
+# tests/test_my_feature.py
+import pytest
+from ttadev.primitives import MockPrimitive, WorkflowContext
+
+
+@pytest.mark.asyncio
+async def test_my_workflow_succeeds() -> None:
+    # Arrange
+    mock = MockPrimitive("step1", return_value={"status": "ok"})
+    ctx = WorkflowContext(workflow_id="test-run")
+
+    # Act
+    result = await mock.execute("input", ctx)
+
+    # Assert
+    assert result == {"status": "ok"}
+    assert mock.call_count == 1
+```
+
+### 6.2 MockPrimitive API
+
+```python
+from ttadev.primitives import MockPrimitive
+
+# Return a static value
+mock = MockPrimitive("name", return_value={"key": "value"})
+
+# Raise an exception
+mock = MockPrimitive("name", raise_error=ValueError("boom"))
+
+# Custom behaviour
+async def custom(data: str, ctx: WorkflowContext) -> str:
+    return data.upper()
+mock = MockPrimitive("name", side_effect=custom)
+
+# Inspect after execution
+assert mock.call_count == 1
+assert mock.calls[0][0] == "input"   # mock.calls is list[tuple[input, context]]
+```
+
+### 6.3 Run the test suite
+
+```bash
+make watch          # TDD loop — re-runs on every file change, fail-fast
+make test           # Full run with coverage (required before committing)
+uv run pytest -v    # Single run
+uv run pytest tests/integration/test_multi_agent_proof.py -v  # Canonical proof
+```
+
+### 6.4 Coverage requirements
+
+- New code: **100%** coverage required
+- Overall project: 80%+ enforced by Codecov
+- Use `make test` (not just `uv run pytest`) to generate coverage reports
+
+---
+
+## 7. Code quality gates
+
+Run these before every commit:
+
+```bash
+uv run ruff format .                    # Format
+uv run ruff check . --fix               # Lint + auto-fix
+uvx pyright ttadev/                     # Type check
+uv run pytest -v                        # Tests
+```
+
+Or run all at once:
+
+```bash
+.github/copilot-hooks/post-generation.sh
+```
+
+### Standards checklist
+
+- [ ] `uv` only — never `pip` or `poetry`
+- [ ] Python 3.11+ syntax: `str | None` not `Optional[str]`, `dict[str, Any]` not `Dict`
+- [ ] Type hints on all function signatures
+- [ ] Google-style docstrings
+- [ ] `WorkflowContext` passed explicitly — no globals
+- [ ] Primitives for retry/timeout/circuit-breaker — no manual loops
+- [ ] AAA pattern in tests
+- [ ] Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+
+---
+
+## 8. Routing — what to read before touching specific code
+
+| Area | Read first |
+|------|-----------|
+| Primitive internals | `docs/agents/dev/architecture.md` |
+| Retry / timeout / circuit breaker | `docs/agents/dev/reliability.md` |
+| OTel / Langfuse tracing | `docs/agents/dev/observability.md` |
+| Tests / coverage | `docs/agent-guides/testing-architecture.md` |
+| L0 control plane / leases | `docs/agents/dev/l0-coordination.md` |
+| Agent roles | `docs/agents/runtime/l0-roster.md` |
+
+---
+
+## 9. Skills — on-demand HOW-TO workflows
+
+Skills are step-by-step workflows for common tasks. They live in two places:
+
+| Location | Used by |
+|----------|---------|
+| `.github/skills/` | GitHub Copilot |
+| `.claude/skills/` | Claude Code |
+
+Available skills:
+
+| Skill | When |
+|-------|------|
+| `session-start` | Start of every session — orient, load context |
+| `build-test-verify` | Build → test → lint cycle |
+| `core-conventions` | Writing / reviewing Python code |
+| `git-commit` | Making commits (Conventional Commits format) |
+| `create-pull-request` | Opening PRs |
+| `self-review-checklist` | Pre-merge checklist |
+| `sdd-workflow` | New feature development (spec → plan → tasks → implement) |
+
+---
+
+## 10. MCP tools — structured access to TTA.dev
+
+When running inside an MCP-enabled IDE, these tools are available:
+
+```python
+# First call of every session — returns orientation package
+tta_bootstrap(agent_id="<your-id>", task_hint="<what you're building>")
+
+# Query available primitives
+get_primitive_catalog()
+
+# Check workflow status
+get_workflow_status(workflow_id="<id>")
+
+# Search primitives by capability
+search_primitives(query="retry exponential backoff")
+
+# Get test patterns
+get_test_patterns(pattern_type="async_workflow")
+```
+
+Tools tagged `allowed_callers` support programmatic tool calling (PTC) — they
+return structured JSON that can be parsed and acted on directly in code.
+
+See [`MCP_TOOL_REGISTRY.md`](../MCP_TOOL_REGISTRY.md) for the full tool catalog.
+
+---
+
+## 11. Common patterns — quick reference
+
+### Retry with exponential backoff
+
+```python
+from ttadev.primitives import RetryPrimitive
+workflow = RetryPrimitive(base, max_retries=3, backoff_factor=2.0)
+```
+
+### Fallback chain
+
+```python
+from ttadev.primitives import FallbackPrimitive
+workflow = FallbackPrimitive(primary=fast_service, fallback=slow_service)
+```
+
+### Timeout protection
+
+```python
+from ttadev.primitives import TimeoutPrimitive
+workflow = TimeoutPrimitive(long_task, timeout_seconds=30.0)
+```
+
+### Circuit breaker
+
+```python
+from ttadev.primitives.recovery.circuit_breaker_primitive import (
+    CircuitBreakerConfig, CircuitBreakerPrimitive,
+)
+workflow = CircuitBreakerPrimitive(
+    primitive=api_call,
+    config=CircuitBreakerConfig(failure_threshold=5, recovery_timeout=60.0),
+)
+```
+
+### Cache with custom key
+
+```python
+from ttadev.primitives import CachePrimitive
+workflow = CachePrimitive(
+    base,
+    cache_key_fn=lambda data, ctx: f"{ctx.workflow_id}:{data}",
+    ttl_seconds=300.0,
+)
+```
+
+### Parallel fan-out
+
+```python
+from ttadev.primitives import ParallelPrimitive
+# Operator form:
+workflow = branch_a | branch_b | branch_c
+# Explicit form:
+workflow = ParallelPrimitive([branch_a, branch_b, branch_c])
+results: list = await workflow.execute(input_data, ctx)
+```
+
+### Sequential pipeline
+
+```python
+from ttadev.primitives import SequentialPrimitive
+# Operator form:
+workflow = step_a >> step_b >> step_c
+# Explicit form:
+workflow = SequentialPrimitive([step_a, step_b, step_c])
+```
+
+---
+
+## 12. Where to find more
+
+| Resource | URL / Path |
+|----------|-----------|
+| Full primitive API | [`PRIMITIVES_CATALOG.md`](../PRIMITIVES_CATALOG.md) |
+| Observability setup | [`docs/observability-quickstart.md`](observability-quickstart.md) |
+| L0 workflow walkthrough | [`docs/l0-workflow-walkthrough.md`](l0-workflow-walkthrough.md) |
+| Python standards | [`docs/agent-guides/python-standards.md`](agent-guides/python-standards.md) |
+| Composition deep-dive | [`docs/agent-guides/primitives-patterns.md`](agent-guides/primitives-patterns.md) |
+| Testing deep-dive | [`docs/agent-guides/testing-architecture.md`](agent-guides/testing-architecture.md) |
+| LLM provider strategy | [`docs/agent-guides/llm-provider-strategy.md`](agent-guides/llm-provider-strategy.md) |
+| Secrets / API keys | [`docs/agent-guides/secrets-guide.md`](agent-guides/secrets-guide.md) |
+| SDD constitution | [`docs/agent-guides/sdd-constitution.md`](agent-guides/sdd-constitution.md) |
+| Canonical integration test | [`tests/integration/test_multi_agent_proof.py`](../tests/integration/test_multi_agent_proof.py) |
+| Showcase example | [`examples/showcase/`](../examples/showcase/) |
+| Resilient LLM pipeline | [`examples/resilient_llm_pipeline.py`](../examples/resilient_llm_pipeline.py) |

--- a/docs/observability-quickstart.md
+++ b/docs/observability-quickstart.md
@@ -1,30 +1,36 @@
 # Observability Quickstart
 
-Get the TTA.dev observability dashboard running, watch live traces from a real workflow, and
-optionally ship those traces to Langfuse for persistent APM.
+Get the TTA.dev observability dashboard running, watch live traces from the showcase pipeline,
+and optionally ship those traces to Langfuse for persistent LLM-specific APM.
 
 ---
 
-## 1. Prerequisites
+## What You Get
 
-| Requirement | Version |
-|-------------|---------|
-| Python | 3.11+ |
-| uv | latest (`pip install uv`) |
-| TTA.dev | installed via `./setup.sh` or `uv sync` |
+| Layer | What it provides |
+|-------|-----------------|
+| **Local dashboard** (`http://localhost:8000`) | Real-time session tree, per-span timing bars, primitive-type badges, and a WebSocket feed — zero external services required. |
+| **Langfuse** (optional) | Persistent LLM-specific telemetry: token counts, cost estimates, model comparisons, prompt versioning, and inline quality scoring. |
 
-If you haven't set up the repo yet, follow [GETTING_STARTED.md](../GETTING_STARTED.md) first.
+The two layers complement each other: the local dashboard gives you instant visibility during
+development; Langfuse gives you long-term analytics and LLM evaluation across runs.
 
 ---
 
-## 2. Start the Dashboard
+## 1. Start the Dashboard
 
 ```bash
 uv run python -m ttadev.observability
 ```
 
-The entry point is idempotent — if the server is already running on port 8000 it opens the
-browser and exits cleanly instead of erroring.
+The entry point is **idempotent** — if the server is already running on port 8000 it opens the
+browser tab and exits cleanly instead of erroring.
+
+Alternatively, use the installed script:
+
+```bash
+tta-dashboard
+```
 
 Expected output:
 
@@ -33,109 +39,140 @@ TTA.dev Observability Dashboard → http://localhost:8000
 Press Ctrl+C to stop.
 ```
 
-Your default browser opens automatically. The dashboard shows:
+Your default browser opens automatically to `http://localhost:8000`. The dashboard shows:
 
-- **Session tree** — each workflow run appears as a session; sessions are listed newest-first
-  via `GET /api/v2/sessions`.
-- **Span timeline** — the individual primitive executions (spans) inside each session, with
-  timing bars and status badges.
-- **Live updates** — the dashboard subscribes to `WS /ws` and re-renders whenever a new span
-  arrives; no manual refresh required.
+- **Session tree** — each workflow run is a session, listed newest-first (`GET /api/v2/sessions`).
+- **Span timeline** — the individual primitive executions inside each session, with timing bars
+  and status badges (`"success"` / `"error"` / `"running"`).
+- **Live updates** — the UI subscribes to `WS /ws` and re-renders when new spans arrive;
+  no manual refresh required.
 
 > **Tip:** The dashboard reads from `.observability/traces.jsonl` (OTEL spans) and
-> `.tta/traces/` (file-based collector). Both files accumulate across restarts — traces are
-> not cleared when you stop the server.
+> `.tta/traces/` (file-based collector). Both files accumulate across restarts — traces persist
+> when you stop and restart the server.
 
 ---
 
-## 3. Run a Workflow and Watch It
+## 2. Run the Showcase
 
-Open a second terminal and run this self-contained snippet. No API key required.
+The **Smart Code Reviewer** (`examples/showcase/`) is the canonical demonstration workflow.
+It runs two static agents in parallel and then calls an LLM router — all wired with TTA.dev
+primitives.
 
-```python
-# run_demo.py
-import asyncio
-
-import ttadev
-from ttadev.primitives.core.base import LambdaPrimitive, WorkflowContext
-from ttadev.primitives.recovery.retry import RetryPrimitive
-
-# Enable OTel tracing → writes to .observability/traces.jsonl
-ttadev.initialize_observability()
-
-
-async def flaky_task(data: dict, ctx: WorkflowContext) -> dict:
-    """Simulate a task that succeeds on the first attempt."""
-    await asyncio.sleep(0.1)
-    return {**data, "result": "ok"}
-
-
-async def main() -> None:
-    # Wrap any callable as a primitive, then add retry logic
-    base = LambdaPrimitive(flaky_task)
-    workflow = RetryPrimitive(base, max_attempts=3)
-
-    ctx = WorkflowContext(workflow_id="observability-demo")
-    result = await workflow.execute({"input": "hello"}, ctx)
-    print("Result:", result)
-
-
-asyncio.run(main())
-```
+Start the dashboard first (§1), then in a second terminal:
 
 ```bash
-uv run python run_demo.py
+# Review a file in mock mode — no API key required, fully deterministic
+uv run python -m examples.showcase.main examples/showcase/router.py --mock
 ```
 
-Switch back to the dashboard tab. Within a few seconds a new session labelled
-`observability-demo` appears in the session list, with one span for the `RetryPrimitive`
-wrapping the `LambdaPrimitive` execution.
+To output raw JSON instead of Markdown:
+
+```bash
+uv run python -m examples.showcase.main examples/showcase/router.py --mock --json
+```
+
+To use a real LLM (requires at least one of `GROQ_API_KEY`, `GEMINI_API_KEY`, or a running
+Ollama instance):
+
+```bash
+uv run python -m examples.showcase.main path/to/your_file.py
+```
+
+**What you'll see in the terminal:**
+
+```markdown
+# Code Review: `router.py`
+
+## Security Review
+✅ No issues detected.
+
+## Quality Review
+- Line 55: `_make_smart_primitive` is missing a return type annotation
+...
+
+## LLM Review
+[MockLLM/reviewer] Reviewed 90 lines.
+No issues found (mock mode — attach an API key for real analysis).
+```
+
+Switch to the dashboard tab. Within a few seconds a new session labelled
+`showcase-router` appears in the session list with spans for each primitive.
 
 ---
 
-## 4. Trace Anatomy
+## 3. Interpreting Traces
 
-Each span in the dashboard corresponds to one `ProcessedSpan` record. The key fields are:
+### Span hierarchy
+
+The showcase produces the following span tree for each file review:
+
+```
+showcase-{filename}          ← WorkflowContext.workflow_id (root trace)
+├── ParallelPrimitive        ← static agents run concurrently
+│   ├── SecurityAgent        ← scans for hardcoded secrets, eval/exec, SQL injection
+│   └── QAAgent              ← checks docstrings, type hints, line length
+└── FallbackPrimitive        ← LLM router with automatic fallback
+    └── RetryPrimitive       ← up to 2 retries with 1.5× backoff
+        └── smart-router-chat  ← LambdaPrimitive wrapping SmartRouterPrimitive
+                                 (Groq → Gemini → Ollama → MockLLM cascade)
+```
+
+In `--mock` mode the `FallbackPrimitive` short-circuits directly to `MockLLMPrimitive` and
+the `RetryPrimitive`/`smart-router-chat` spans are omitted.
+
+### Key span fields
+
+Each span in the dashboard corresponds to one `ProcessedSpan` record:
 
 | Field | What it means |
 |-------|---------------|
-| `trace_id` | Unique identifier for the entire workflow run — every span in one `workflow.execute()` call shares this ID. |
-| `span_id` | Identifier for a **single primitive execution** within that run. |
-| `primitive_type` | Which primitive class handled this span — e.g. `RetryPrimitive`, `CachePrimitive`, `CircuitBreakerPrimitive`. Inferred from the span name if not set explicitly. |
-| `status` | `"success"`, `"error"`, or `"running"` — whether the primitive completed, failed, or is still executing. |
-| `duration_ms` | Wall-clock execution time for this span in milliseconds. |
-| `provider` | For LLM-backed primitives: the AI provider (`"Anthropic"`, `"OpenAI"`, `"Ollama"`, …). For pure framework spans the value is `"TTA.dev"`. |
-| `model` | Model identifier reported by the provider, e.g. `"claude-3-5-sonnet-20241022"`. `"unknown"` for non-LLM spans. |
-| `parent_span_id` | Links child spans to their parent, forming the tree you see in the timeline. `None` on root spans. |
-| `agent_role` | Which agent (if any) submitted the span — e.g. `"developer"`, `"qa"`. |
+| `trace_id` | Shared by every span in one `workflow.execute()` call. |
+| `span_id` | Unique to a single primitive execution within that run. |
+| `parent_span_id` | Links child spans to their parent, forming the tree. `None` on root spans. |
+| `primitive_type` | Which class handled this span — e.g. `ParallelPrimitive`, `RetryPrimitive`, `SecurityAgent`. |
+| `status` | `"success"`, `"error"`, or `"running"`. |
+| `duration_ms` | Wall-clock time for this span in milliseconds. |
+| `provider` | AI provider for LLM spans (`"Groq"`, `"Gemini"`, `"Ollama"`). Framework spans report `"TTA.dev"`. |
+| `model` | Model identifier, e.g. `"llama-3.3-70b-versatile"`. `"unknown"` for non-LLM spans. |
+| `agent_role` | Which agent submitted the span — e.g. `"developer"`, `"qa"`. |
 
-You can inspect the raw data directly:
+### What a healthy trace looks like
+
+- `ParallelPrimitive` completes in roughly the time of the **slower** of its two children
+  (both agents run concurrently, not sequentially).
+- `SecurityAgent` and `QAAgent` are pure-Python static checks — expect `duration_ms < 50`.
+- If a real LLM is used, `smart-router-chat` dominates wall time (hundreds of ms to seconds).
+- All spans should carry `status: "success"`. An `"error"` status on `FallbackPrimitive`
+  means both the primary router **and** the MockLLM fallback failed — extremely unlikely.
+
+### Inspect via API
 
 ```bash
 # List all sessions (newest first)
 curl -s http://localhost:8000/api/v2/sessions | python3 -m json.tool
 
-# Spans for the first session
-SESSION_ID=$(curl -s http://localhost:8000/api/v2/sessions | python3 -c \
-  "import sys, json; print(json.load(sys.stdin)[0]['id'])")
+# Spans for the most recent session
+SESSION_ID=$(curl -s http://localhost:8000/api/v2/sessions | \
+  python3 -c "import sys, json; print(json.load(sys.stdin)[0]['id'])")
 curl -s "http://localhost:8000/api/v2/sessions/${SESSION_ID}/spans" | python3 -m json.tool
 ```
 
 ---
 
-## 5. Connect Langfuse (Optional — External APM)
+## 4. Connect Langfuse (Optional)
 
 [Langfuse](https://cloud.langfuse.com) is an open-source LLM observability platform. TTA.dev
-ships a separate integration package `tta-apm-langfuse` that wraps any primitive and
-forwards traces.
+ships a separate integration package `tta-apm-langfuse` that wraps any primitive and forwards
+traces with full LLM metadata (tokens, cost, model comparisons, quality scores).
 
-### 5a. Install the integration
+### 4a. Install the integration
 
 ```bash
 uv pip install -e ttadev/observability/apm/langfuse
 ```
 
-### 5b. Set credentials
+### 4b. Set credentials
 
 Create a project at [cloud.langfuse.com](https://cloud.langfuse.com) (free tier available),
 then export your keys:
@@ -146,10 +183,10 @@ export LANGFUSE_SECRET_KEY="sk-lf-..."
 export LANGFUSE_BASE_URL="https://cloud.langfuse.com"   # or your self-hosted URL
 ```
 
-### 5c. Instrument a primitive
+`from_env()` reads `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL`
+(falling back to `LANGFUSE_HOST` if `LANGFUSE_BASE_URL` is unset).
 
-Use `LangFuseIntegration.from_env()` — it reads `LANGFUSE_PUBLIC_KEY`,
-`LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` automatically:
+### 4c. Instrument a primitive
 
 ```python
 import asyncio
@@ -165,10 +202,10 @@ async def my_task(data: dict, ctx: WorkflowContext) -> dict:
 
 
 async def main() -> None:
-    # Reads LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_BASE_URL from env
+    # Reads LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_BASE_URL from env
     apm = LangFuseIntegration.from_env()
 
-    # Instrument the primitive — wraps execute() with @observe tracing
+    # Wrap any primitive — execute() is traced automatically
     base = LambdaPrimitive(my_task)
     workflow = apm.instrument(RetryPrimitive(base, max_attempts=2))
 
@@ -176,36 +213,44 @@ async def main() -> None:
     result = await workflow.execute({"hello": "world"}, ctx)
     print("Result:", result)
 
-    # Flush buffered spans before the process exits
+    # Always flush before the process exits
     await apm.aflush()
 
 
 asyncio.run(main())
 ```
 
-### 5d. Verify in Langfuse UI
+### 4d. Verify in Langfuse
 
 1. Open your Langfuse project → **Traces**.
-2. A trace named `RetryPrimitive` (or the custom `trace_name` you passed to `instrument()`)
-   should appear within ~10 seconds.
-3. Click the trace to see the observation tree with `duration_seconds`, `primitive_type`,
-   `status`, and any error metadata.
+2. A trace named `RetryPrimitive` (or the `trace_name` you passed to `instrument()`) appears
+   within ~10 seconds.
+3. Click the trace to see the observation tree: `duration_seconds`, `primitive_type`, `status`,
+   and error metadata on failure.
 
----
+### 4e. What Langfuse adds vs the local dashboard
 
-## 5e. Session & User Attribution (Automatic)
+| Feature | Local dashboard | Langfuse |
+|---------|-----------------|---------|
+| Real-time span feed | ✅ | ❌ (async flush) |
+| Span tree + timing | ✅ | ✅ |
+| Token / cost tracking | ❌ | ✅ |
+| Model comparison | ❌ | ✅ |
+| Prompt versioning | ❌ | ✅ |
+| Inline quality scoring | ❌ | ✅ (`score_inline()`) |
+| Long-term retention | file-based | cloud / self-hosted |
 
-When `from_env()` is called, TTA.dev auto-populates **session_id** and **user_id** on the
-integration singleton so every observation is attributed without manual setup:
+### 4f. Session and user attribution (automatic)
 
-| Attribute | Source | Example value |
-|-----------|--------|---------------|
-| `user_id` | `get_agent_id()` from `ttadev.observability.agent_identity` | `"copilot"`, `"cline"`, `"adam"` |
+`from_env()` auto-populates `session_id` and `user_id` so every observation is attributed
+without manual setup:
+
+| Attribute | Source | Example |
+|-----------|--------|---------|
+| `user_id` | `ttadev.observability.agent_identity.get_agent_id()` | `"copilot"`, `"cline"` |
 | `session_id` | Active L0 run ID from `ControlPlaneService` | `"run-abc123"` |
 
-If either source is unavailable the attribute stays `None` — Langfuse simply omits it.
-
-You can also set them explicitly:
+Override explicitly when needed:
 
 ```python
 apm = LangFuseIntegration.from_env()
@@ -217,31 +262,48 @@ Or per-call on `create_generation()`:
 
 ```python
 apm.create_generation(
-    name="my-gen", model="llama-3", input=prompt, output=reply,
-    session_id="run-xyz", user_id="my-agent",
+    name="my-gen",
+    model="llama-3",
+    input=prompt,
+    output=reply,
+    session_id="run-xyz",
+    user_id="my-agent",
 )
 ```
 
----
+### 4g. Inline scoring
 
-## 5f. Trace URL Logging
+```python
+apm.create_generation(
+    name="my-gen",
+    model="llama-3.3-70b",
+    input="Summarise this article …",
+    output="The article discusses …",
+)
+# Score the trace immediately — no trace_id bookkeeping
+apm.score_inline(score=0.9, name="quality", comment="Concise and accurate")
+await apm.aflush()
+```
 
-After each `create_generation()` call, the integration logs the Langfuse trace URL at
-`DEBUG` level so you can jump straight to the trace in the Langfuse UI:
+`score_inline()` is silent on failure — it never raises even if Langfuse is unreachable.
+
+### 4h. Trace URL in logs
+
+After each `create_generation()` call the integration logs the Langfuse trace URL at `DEBUG`
+level:
 
 ```
 DEBUG tta_apm_langfuse.integration Langfuse trace: https://cloud.langfuse.com/project/...
 ```
 
-Enable debug logging in your script:
+Enable it with:
 
 ```python
 import logging
 logging.basicConfig(level=logging.DEBUG)
 ```
 
-`create_generation()` also returns the trace ID string (or `None` if tracing is off),
-which you can pass to other systems:
+`create_generation()` also returns the trace ID string (or `None` when tracing is off):
 
 ```python
 trace_id = apm.create_generation(name="gen", model="llama-3", input=p, output=r)
@@ -250,95 +312,104 @@ print("Trace ID:", trace_id)
 
 ---
 
-## 5g. Inline Scoring
+## 5. Production Setup
 
-Score the current trace immediately after a generation — no `trace_id` bookkeeping required:
+For production environments, route spans to an OpenTelemetry Collector instead of (or in
+addition to) the local JSONL file.
 
-```python
-import asyncio
-from tta_apm_langfuse import LangFuseIntegration
+### 5a. Configure the OTLP exporter
 
-
-async def main() -> None:
-    apm = LangFuseIntegration.from_env()
-
-    # Record the LLM generation
-    apm.create_generation(
-        name="my-gen",
-        model="llama-3.3-70b",
-        input="Summarise this article …",
-        output="The article discusses …",
-    )
-
-    # Score immediately — uses score_current_trace() internally
-    apm.score_inline(score=0.9, name="quality", comment="Concise and accurate")
-
-    await apm.aflush()
-
-
-asyncio.run(main())
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://your-collector:4317"
+export OTEL_SERVICE_NAME="tta-dev"
+export OTEL_TRACES_SAMPLER="parentbased_traceidratio"
+export OTEL_TRACES_SAMPLER_ARG="1.0"
 ```
 
-`score_inline()` fails silently — it will never raise even if Langfuse is unreachable.
+### 5b. Initialize programmatically
+
+```python
+from ttadev.observability.observability_integration.apm_setup import initialize_observability
+
+initialize_observability(
+    service_name="tta-dev",
+    service_version="1.0.0",
+    enable_prometheus=True,   # exposes /metrics on port 9464 for Prometheus scraping
+    enable_console_traces=False,  # disable console noise in production
+)
+```
+
+`initialize_observability()` returns `True` on success and `False` in degraded (no-op) mode
+when `opentelemetry-sdk` is not installed — it never raises, so it is safe to call
+unconditionally.
+
+### 5c. Prometheus metrics
+
+When `enable_prometheus=True`, a Prometheus scrape endpoint is available at
+`http://localhost:9464/metrics`. Key metrics:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `workflow.duration` | Histogram | End-to-end workflow execution time |
+| `workflow.success_count` | Counter | Successful completions |
+| `workflow.failure_count` | Counter | Failed executions |
+| `primitive.retry_count` | Counter | Retries per primitive |
+| `cache.hit_rate` | Gauge | Cache hit/miss ratio |
+
+### 5d. Shutdown hook
+
+Always register a shutdown handler to flush pending spans:
+
+```python
+import atexit
+from ttadev.observability.observability_integration.apm_setup import shutdown_observability
+
+atexit.register(shutdown_observability)
+```
 
 ---
 
-## 5h. L0 Runs as Langfuse Sessions
-
-When your code calls `ControlPlaneService.claim_task()`, TTA.dev automatically binds the
-new run's ID as the Langfuse `session_id` on the global singleton.  Every subsequent LLM
-call made during that run therefore appears under a single session in the Langfuse UI —
-no manual wiring required.
-
-```python
-from ttadev.control_plane.service import ControlPlaneService
-
-svc = ControlPlaneService()
-result = svc.claim_task("task-123")
-# → Langfuse session_id is now result.run.id
-# → All LLM generations within this run are grouped under that session
-```
-
-The hook is guarded in a `try/except` so a missing or misconfigured Langfuse installation
-never breaks the control plane.
-
----
-
-## 6. Troubleshooting
+## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
-| Dashboard blank — no sessions listed | No workflow has run yet | Run the snippet from §3 and wait ~5 s for ingestion |
-| Port 8000 already in use | Another process (or a previous server instance) | `lsof -ti:8000 \| xargs kill` then restart, or use a different machine port forwarding |
-| `curl /api/v2/sessions` returns `[]` after running a workflow | OTel exporter writes asynchronously | Wait 5–10 s, then refresh; check `.observability/traces.jsonl` exists |
-| Langfuse auth error (`401 Unauthorized`) | Wrong or expired keys | Double-check `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` match the project |
-| Langfuse traces never appear | `aflush()` not called before exit | Add `await apm.aflush()` (or `apm.flush()` in sync code) at the end of your script |
-| WebSocket not connecting (`WS /ws` errors in browser console) | Browser extension blocking WebSocket upgrades | Try incognito / private mode, or disable extensions |
-| Traces accumulate forever | Expected — JSONL files are append-only | Archive or truncate `.observability/traces.jsonl` and `.tta/traces/` manually when needed |
+| Dashboard blank — no sessions listed | No workflow has run yet | Run the showcase (§2) and wait ~5 s for ingestion |
+| Port 8000 already in use | Previous server instance still running | `lsof -ti:8000 \| xargs kill`, then restart |
+| `GET /api/v2/sessions` returns `[]` after a run | OTel exporter writes asynchronously | Wait 5–10 s; check `.observability/traces.jsonl` exists |
+| Langfuse `401 Unauthorized` | Wrong or expired keys | Verify `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` match your project |
+| Langfuse traces never appear | `aflush()` not called before exit | Add `await apm.aflush()` (or `apm.flush()` in sync code) at the end of the script |
+| WebSocket errors in browser console | Browser extension blocking WS upgrades | Try incognito mode or disable extensions |
+| Traces accumulate indefinitely | JSONL files are append-only by design | Archive or truncate `.observability/traces.jsonl` and `.tta/traces/` manually |
 
 ---
 
-## 7. Available API Endpoints
+## Available API Endpoints
 
-The running server exposes the following routes (full list in `ttadev/observability/server.py`):
+Full route list is in `ttadev/observability/server.py`:
 
 ```
-GET  /                             → dashboard HTML
-GET  /api/v2/health                → health + session info
-GET  /api/v2/sessions              → all sessions (newest first)
-GET  /api/v2/sessions/current      → active session or 404
-GET  /api/v2/sessions/{id}         → session detail + provider summary
-GET  /api/v2/sessions/{id}/spans   → all spans for a session
-GET  /api/v2/primitives            → primitives catalog
-GET  /api/v2/projects              → project sessions (newest first)
-WS   /ws                           → real-time span / session events
+GET  /                               → dashboard HTML
+GET  /api/v2/health                  → health + session info
+GET  /api/v2/sessions                → all sessions (newest first)
+GET  /api/v2/sessions/current        → active session or 404
+GET  /api/v2/sessions/{id}           → session detail + provider summary
+GET  /api/v2/sessions/{id}/spans     → all spans for a session
+GET  /api/v2/cgc/{view}              → CGC graph data
+GET  /api/v2/cgc/live                → active primitive names (live overlay)
+GET  /api/v2/primitives              → primitives catalog
+GET  /api/v2/projects                → project sessions (newest first)
+GET  /api/v2/projects/{id}           → project session detail
+GET  /api/v2/projects/{id}/sessions  → sessions belonging to a project
+WS   /ws                             → real-time span / session events
 ```
 
 ---
 
-## Related docs
+## Related Docs
 
 - [GETTING_STARTED.md](../GETTING_STARTED.md) — full environment setup
+- [QUICKSTART.md](../QUICKSTART.md) — minimal verified proof path
 - [PRIMITIVES_CATALOG.md](../PRIMITIVES_CATALOG.md) — all available primitives
 - [Langfuse consolidation notes](observability/LANGFUSE_CONSOLIDATION.md)
 - [Observability span propagation](observability-span-propagation.md)
+- [Agent observability guide](agent-guides/observability-guide.md)


### PR DESCRIPTION
Closes #305
Closes #310

## What this PR does

### QUICKSTART.md (issue #310)
- Adds a 30-second version at the very top — minimal commands to see something working immediately, no API key required
- Shows the showcase pipeline as a real working demo
- Includes a working primitive example with correct import paths (verified)
- Adds a next-reads table linking to deeper docs
- Removes stale command references

### docs/agent-first.md (issue #305)
New guide for coding agents integrating TTA.dev:
- Orientation chain — ordered table of what to read first
- Machine-readable repo layout
- The one rule: never write manual loops, always use primitives
- Primitive composition pattern with import paths and operators
- WorkflowContext usage
- Test patterns with MockPrimitive API and make watch / make test
- Quality gates checklist
- Routing table — which guide to read before touching each area
- Skills in .github/skills/ and .claude/skills/
- MCP tools including tta_bootstrap
- Common patterns quick-reference